### PR TITLE
Publica mensagens como persistent

### DIFF
--- a/lib/brokers/rabbit/index.js
+++ b/lib/brokers/rabbit/index.js
@@ -77,6 +77,7 @@ module.exports = class RabbitBroker {
                        try_count,
                      },
                      messageId: executionId,
+                     persistent: true
                    }
         )
       else if (queue) {
@@ -92,6 +93,7 @@ module.exports = class RabbitBroker {
               try_count,
             },
             messageId: executionId,
+            persistent: true
           }
         )
       }

--- a/test/integration/publish.spec.js
+++ b/test/integration/publish.spec.js
@@ -29,7 +29,7 @@ describe("publish", () => {
     })
 
     it("message should be delivered in correct queue", function*() {
-      expect(msg).to.exists
+      expect(msg).to.not.be.false
     })
 
     it("should publish the correct content", () => {
@@ -44,6 +44,7 @@ describe("publish", () => {
 
   context("by queue", () => {
 
+    let msg
     before(function*() {
 
       yield RabbitHelper.build()
@@ -56,11 +57,20 @@ describe("publish", () => {
       })
 
       yield publish({ a: "b" })
+
+      const msg = yield RabbitHelper.getFrom("clicks_warehouse", { remove: true })
     })
 
     it("message should be delivered in correct queue", function*() {
-      const msg = yield RabbitHelper.getFrom("clicks_warehouse", { remove: true })
+      expect(msg).to.not.be.false
+    })
+
+    it("should publish the correct content", () => {
       expect(msg.content.toString()).to.be.equal("{\"a\":\"b\"}")
+    })
+
+    it("should be a persistent message", () => {
+      expect(msg.properties.deliveryMode).to.be.equal(2)
     })
   })
 })

--- a/test/integration/publish.spec.js
+++ b/test/integration/publish.spec.js
@@ -10,6 +10,7 @@ describe("publish", () => {
 
   context("by routingKey", () => {
 
+    let msg
     before(function*() {
 
       yield RabbitHelper.build()
@@ -24,12 +25,21 @@ describe("publish", () => {
       })
 
       yield publish({ a: "b" })
+      msg = yield RabbitHelper.getFrom("clicks_warehouse", { remove: true })
     })
 
     it("message should be delivered in correct queue", function*() {
-      const msg = yield RabbitHelper.getFrom("clicks_warehouse", { remove: true })
+      expect(msg).to.exists
+    })
+
+    it("should publish the correct content", () => {
       expect(msg.content.toString()).to.be.equal("{\"a\":\"b\"}")
     })
+
+    it("should be a persistent message", () => {
+      expect(msg.properties.deliveryMode).to.be.equal(2)
+    })
+
   })
 
   context("by queue", () => {

--- a/test/integration/publish.spec.js
+++ b/test/integration/publish.spec.js
@@ -58,7 +58,7 @@ describe("publish", () => {
 
       yield publish({ a: "b" })
 
-      const msg = yield RabbitHelper.getFrom("clicks_warehouse", { remove: true })
+      msg = yield RabbitHelper.getFrom("clicks_warehouse", { remove: true })
     })
 
     it("message should be delivered in correct queue", function*() {


### PR DESCRIPTION
A publicações que a lib faz são de mensagens com o delivery mode transient. Mudei para publicar como persistent.
[Referência](https://stackoverflow.com/questions/2344022/what-is-the-delivery-mode-in-amqp)

O ideal é deixar o delivery mode configurável, mas não é o escopo da PR